### PR TITLE
Update README to use the correct VSCode version

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
 		"connor4312.esbuild-problem-matchers",
-		"ms-vscode.extension-test-runner"
+		"ms-vscode.extension-test-runner",
+		"alexjsully.workspace-wiki"
 	]
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Workspace Wiki is a VS Code extension that scans your workspace for documentatio
 
 ## Requirements
 
-- VS Code 1.105+
+- VS Code 1.99.3+
 
 ## Extension Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@trivago/prettier-plugin-sort-imports": "^5.2.2",
 				"@types/jest": "^30.0.0",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^24.9.1",
+				"@types/node": "^24.9.2",
 				"@types/vscode": "^1.99.3",
 				"@typescript-eslint/eslint-plugin": "^8.46.2",
 				"@typescript-eslint/parser": "^8.46.2",
@@ -211,22 +211,22 @@
 			}
 		},
 		"node_modules/@azure/msal-browser": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.25.1.tgz",
-			"integrity": "sha512-kAdOSNjvMbeBmEyd5WnddGmIpKCbAAGj4Gg/1iURtF+nHmIfS0+QUBBO3uaHl7CBB2R1SEAbpOgxycEwrHOkFA==",
+			"version": "4.26.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.26.0.tgz",
+			"integrity": "sha512-Ie3SZ4IMrf9lSwWVzzJrhTPE+g9+QDUfeor1LKMBQzcblp+3J/U1G8hMpNSfLL7eA5F/DjjPXkATJ5JRUdDJLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.13.0"
+				"@azure/msal-common": "15.13.1"
 			},
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@azure/msal-common": {
-			"version": "15.13.0",
-			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.0.tgz",
-			"integrity": "sha512-8oF6nj02qX7eE/6+wFT5NluXRHc05AgdCC3fJnkjiJooq8u7BcLmxaYYSwc2AfEkWRMRi6Eyvvbeqk4U4412Ag==",
+			"version": "15.13.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.1.tgz",
+			"integrity": "sha512-vQYQcG4J43UWgo1lj7LcmdsGUKWYo28RfEvDQAEMmQIMjSFufvb+pS0FJ3KXmrPmnWlt1vHDl3oip6mIDUQ4uA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -234,13 +234,13 @@
 			}
 		},
 		"node_modules/@azure/msal-node": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.0.tgz",
-			"integrity": "sha512-23BXm82Mp5XnRhrcd4mrHa0xuUNRp96ivu3nRatrfdAqjoeWAGyD0eEAafxAOHAEWWmdlyFK4ELFcdziXyw2sA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.1.tgz",
+			"integrity": "sha512-HszfqoC+i2C9+BRDQfuNUGp15Re7menIhCEbFCQ49D3KaqEDrgZIgQ8zSct4T59jWeUIL9N/Dwiv4o2VueTdqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.13.0",
+				"@azure/msal-common": "15.13.1",
 				"jsonwebtoken": "^9.0.0",
 				"uuid": "^8.3.0"
 			},
@@ -2829,9 +2829,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+			"version": "24.9.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
+			"integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3693,11 +3693,11 @@
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/brace-expansion": "^5.0.0"
 			},
@@ -5392,9 +5392,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.241",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.241.tgz",
-			"integrity": "sha512-ILMvKX/ZV5WIJzzdtuHg8xquk2y0BOGlFOxBVwTpbiXqWIH0hamG45ddU4R3PQ0gYu+xgo0vdHXHli9sHIGb4w==",
+			"version": "1.5.242",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.242.tgz",
+			"integrity": "sha512-msZ7SYGFpXkm/iUizlMrm/FPNeYo8uSltQccLVFO3fV4RN2JWGdG7Aatztxtw3uDWp3DkupfkrosLjUnhY+iOw==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9922,9 +9922,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-abi": {
-			"version": "3.78.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
-			"integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+			"version": "3.79.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.79.0.tgz",
+			"integrity": "sha512-Pr/5KdBQGG8TirdkS0qN3B+f3eo8zTOfZQWAxHoJqopMz2/uvRnG+S4fWu/6AZxKei2CP2p/psdQ5HFC2Ap5BA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
 		"@trivago/prettier-plugin-sort-imports": "^5.2.2",
 		"@types/jest": "^30.0.0",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^24.9.1",
+		"@types/node": "^24.9.2",
 		"@types/vscode": "^1.99.3",
 		"@typescript-eslint/eslint-plugin": "^8.46.2",
 		"@typescript-eslint/parser": "^8.46.2",


### PR DESCRIPTION
This pull request makes minor updates to the development environment and documentation. The most notable changes are the addition of a new recommended VS Code extension, an update to the minimum required VS Code version in the documentation, and a patch-level update to a development dependency.

- **Development Environment Updates:**
  * Added `alexjsully.workspace-wiki` to the list of recommended VS Code extensions in `.vscode/extensions.json`.
  * Updated `@types/node` development dependency from version `24.9.1` to `24.9.2` in `package.json`.

- **Documentation:**
  * Changed the minimum required VS Code version in the `README.md` from `1.105+` to `1.99.3+` to accurately reflect compatibility.